### PR TITLE
Add personal blog landing page

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="zh-Hans">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>林新宇 · 个人博客</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="logo">Xinyu.log</div>
+      <nav>
+        <a href="#about">关于我</a>
+        <a href="#writing">文章</a>
+        <a href="#newsletter">通讯</a>
+        <a href="#contact">联系</a>
+      </nav>
+      <button class="theme-toggle" aria-label="切换主题">
+        <span>☀️</span>
+        <span>🌙</span>
+      </button>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div>
+          <p class="eyebrow">你好，我是林新宇 · 产品型前端工程师</p>
+          <h1>
+            记录构建友好产品的道路，<br />
+            分享代码、设计与学习笔记。
+          </h1>
+          <p class="lead">
+            在深圳从事 Web 和跨端产品的设计开发，热衷于用清晰的文字和
+            demo 分享实践经验，帮助更多人快速搭建创意原型与数字作品。
+          </p>
+          <div class="hero-cta">
+            <a class="btn primary" href="#writing">阅读最新文章</a>
+            <a class="btn ghost" href="#newsletter">订阅周刊</a>
+          </div>
+          <ul class="stats">
+            <li>
+              <span>7+</span>
+              <p>年产品/前端经验</p>
+            </li>
+            <li>
+              <span>120+</span>
+              <p>文章与笔记</p>
+            </li>
+            <li>
+              <span>15K+</span>
+              <p>Newsletter 订阅</p>
+            </li>
+          </ul>
+        </div>
+        <div class="hero-card">
+          <p class="card-title">正在折腾</p>
+          <ul>
+            <li>
+              <strong>AI 辅助设计</strong>
+              <span>探索生成式 UI 工具与 Prompt Patterns</span>
+            </li>
+            <li>
+              <strong>个人知识库</strong>
+              <span>基于 Obsidian + Astro 的写作流程</span>
+            </li>
+            <li>
+              <strong>数字花园</strong>
+              <span>公共笔记实验室，欢迎围观</span>
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section id="about" class="about">
+        <div class="section-heading">
+          <p class="eyebrow">关于作者</p>
+          <h2>持续好奇，是我创作的底气</h2>
+        </div>
+        <div class="about-grid">
+          <article>
+            <h3>专注于让体验更丝滑</h3>
+            <p>
+              关注产品策略、设计系统与高质量实现。擅长将模糊想法拆解为可执行的原型，靠快速迭代验证方向，让团队在确定性中前进。
+            </p>
+          </article>
+          <article>
+            <h3>热爱写作与讲述</h3>
+            <p>
+              通过博客、播客与线下沙龙分享内容，主题涉及 AI 工作流、前端工程、设计协作与自我管理，期待与同行共同进步。
+            </p>
+          </article>
+          <article>
+            <h3>正在寻找新的合作</h3>
+            <p>
+              若你在寻找副业合伙人、顾问或讲师，可通过页面底部的表单联系我。也欢迎投递项目想法，一起把脑洞变成作品。
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section id="writing" class="writing">
+        <div class="section-heading">
+          <p class="eyebrow">最新创作</p>
+          <h2>精选文章与速记</h2>
+          <p>
+            每周更新 2~3 篇内容，涵盖产品方法论、前端工程、AI 助手与个人成长
+            4 个板块。你可以通过标签筛选或搜索标题。
+          </p>
+        </div>
+
+        <div class="filters">
+          <div class="tags" id="tagFilters"></div>
+          <input type="search" id="search" placeholder="搜索标题或关键词" />
+        </div>
+
+        <div class="featured" id="featuredPost"></div>
+        <div class="post-grid" id="postList"></div>
+      </section>
+
+      <section class="newsletter" id="newsletter">
+        <div class="section-heading">
+          <p class="eyebrow">Newsletter</p>
+          <h2>《半熟创作者》周刊</h2>
+          <p>
+            每周日寄出的长文，分享我的工作流、阅读与实践复盘。订阅后即可获得
+            《个人知识库搭建指南》 PDF。
+          </p>
+        </div>
+        <form class="subscribe-form">
+          <input type="text" placeholder="你的名字" required />
+          <input type="email" placeholder="邮箱" required />
+          <button type="submit" class="btn primary">立即订阅</button>
+        </form>
+        <p class="tiny">
+          * 提交即表示你同意接收邮件并可随时退订，承诺不会发送垃圾信息。
+        </p>
+      </section>
+
+      <section class="contact" id="contact">
+        <div class="section-heading">
+          <p class="eyebrow">联系我</p>
+          <h2>把想法告诉我</h2>
+        </div>
+        <form class="contact-form">
+          <label>
+            姓名
+            <input type="text" required />
+          </label>
+          <label>
+            邮箱
+            <input type="email" required />
+          </label>
+          <label>
+            想合作的内容
+            <textarea rows="4" required></textarea>
+          </label>
+          <button class="btn primary" type="submit">发送</button>
+        </form>
+        <div class="contact-info">
+          <p>
+            或者直接发送邮件至
+            <a href="mailto:hi@xinyu.design">hi@xinyu.design</a>，欢迎提供讲座、咨询与写作邀请。
+          </p>
+          <ul>
+            <li>WeChat：linxinyu</li>
+            <li>Twitter：@xinyu_builds</li>
+            <li>GitHub：@xinyu-dev</li>
+          </ul>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>© <span id="year"></span> Xinyu Lin. 用热爱记录生活与工作。</p>
+      <p>Made with一点点咖啡 & 好奇心。</p>
+    </footer>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/blog/script.js
+++ b/blog/script.js
@@ -1,0 +1,148 @@
+const posts = [
+  {
+    title: "用 Prompt 把设计流程缩短一半",
+    date: "2024-02-18",
+    readingTime: "8 min",
+    tags: ["AI", "Design"],
+    summary:
+      "从需求拆解到稿件输出，完整示范如何把提示词嵌入设计环节，包含模板与常用检查清单。",
+    featured: true,
+  },
+  {
+    title: "打造可复用的前端设计系统",
+    date: "2024-01-30",
+    readingTime: "12 min",
+    tags: ["Frontend", "System"],
+    summary:
+      "分享我在多个项目中沉淀 UI 模块的做法，以及如何把 Figma Tokens 与代码保持同步。",
+  },
+  {
+    title: "Obsidian + Astro 打造数字花园",
+    date: "2024-01-12",
+    readingTime: "9 min",
+    tags: ["Writing", "Tooling"],
+    summary:
+      "记录我搭建第二大脑站点的过程，重点在自动化发布与内容可视化。",
+  },
+  {
+    title: "远程协作下的产品对齐仪式",
+    date: "2023-12-28",
+    readingTime: "6 min",
+    tags: ["Product", "Team"],
+    summary:
+      "三种我常用的对齐节奏模板，帮团队快速聚焦真正重要的问题。",
+  },
+  {
+    title: "让 Side Project 成为技能练习场",
+    date: "2023-12-05",
+    readingTime: "7 min",
+    tags: ["Growth", "Project"],
+    summary:
+      "如何设定可交付的实验目标，让小项目成为持续练手的土壤。",
+  },
+];
+
+const tagFilters = document.getElementById("tagFilters");
+const postList = document.getElementById("postList");
+const featuredPost = document.getElementById("featuredPost");
+const searchInput = document.getElementById("search");
+const themeToggle = document.querySelector(".theme-toggle");
+
+const allTags = [
+  "全部",
+  ...new Set(posts.flatMap((post) => post.tags)),
+];
+let activeTag = "全部";
+
+allTags.forEach((tag) => {
+  const button = document.createElement("button");
+  button.textContent = tag;
+  button.className = "tag-button" + (tag === activeTag ? " active" : "");
+  button.addEventListener("click", () => {
+    activeTag = tag;
+    document
+      .querySelectorAll(".tag-button")
+      .forEach((btn) => btn.classList.remove("active"));
+    button.classList.add("active");
+    renderPosts();
+  });
+  tagFilters.appendChild(button);
+});
+
+searchInput.addEventListener("input", () => renderPosts());
+
+document.querySelector(".subscribe-form")?.addEventListener("submit", (e) => {
+  e.preventDefault();
+  alert("感谢订阅！邮件已安排发送 ✅");
+});
+
+document.querySelector(".contact-form")?.addEventListener("submit", (e) => {
+  e.preventDefault();
+  alert("收到啦，我会尽快回复你 ✉️");
+});
+
+function renderPosts() {
+  const search = searchInput.value.toLowerCase();
+  postList.innerHTML = "";
+  const filtered = posts.filter((post) => {
+    const matchTag = activeTag === "全部" || post.tags.includes(activeTag);
+    const matchSearch =
+      post.title.toLowerCase().includes(search) ||
+      post.summary.toLowerCase().includes(search);
+    return matchTag && matchSearch && !post.featured;
+  });
+
+  filtered.forEach((post) => postList.appendChild(createCard(post)));
+
+  const featured = posts.find((post) => post.featured);
+  if (featured) {
+    featuredPost.innerHTML = "";
+    const card = createCard(featured);
+    const badge = document.createElement("span");
+    badge.className = "eyebrow";
+    badge.textContent = "Featured";
+    card.prepend(badge);
+    featuredPost.appendChild(card);
+  }
+}
+
+function createCard(post) {
+  const card = document.createElement("article");
+  card.className = "post-card";
+  const title = document.createElement("h3");
+  title.textContent = post.title;
+  const meta = document.createElement("p");
+  meta.className = "meta";
+  meta.textContent = `${post.date} · ${post.readingTime}`;
+  const summary = document.createElement("p");
+  summary.textContent = post.summary;
+  const tagList = document.createElement("div");
+  tagList.className = "tag-list";
+  tagList.innerHTML = post.tags.map((tag) => `#${tag}`).join(" ");
+
+  card.append(title, meta, summary, tagList);
+  return card;
+}
+
+function initTheme() {
+  const stored = localStorage.getItem("xinyu-theme");
+  if (stored === "dark") {
+    document.body.classList.add("dark");
+  }
+}
+
+function toggleTheme() {
+  document.body.classList.toggle("dark");
+  const mode = document.body.classList.contains("dark") ? "dark" : "light";
+  localStorage.setItem("xinyu-theme", mode);
+}
+
+themeToggle.addEventListener("click", toggleTheme);
+
+function updateYear() {
+  document.getElementById("year").textContent = new Date().getFullYear();
+}
+
+initTheme();
+renderPosts();
+updateYear();

--- a/blog/style.css
+++ b/blog/style.css
@@ -1,0 +1,363 @@
+:root {
+  color-scheme: light dark;
+  --bg: #faf9f7;
+  --fg: #0f172a;
+  --muted: #475569;
+  --card: #ffffff;
+  --border: #e2e8f0;
+  --accent: #2563eb;
+  --accent-soft: rgba(37, 99, 235, 0.1);
+}
+
+body.dark {
+  --bg: #050816;
+  --fg: #f1f5f9;
+  --muted: #a5b4fc;
+  --card: #0f172a;
+  --border: #1e293b;
+  --accent: #60a5fa;
+  --accent-soft: rgba(96, 165, 250, 0.15);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Space Grotesk", "PingFang SC", "Hiragino Sans", sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+  line-height: 1.7;
+}
+
+img {
+  max-width: 100%;
+}
+
+main {
+  width: min(1100px, 90vw);
+  margin: 0 auto;
+}
+
+section {
+  margin: 96px 0;
+}
+
+.site-header {
+  width: min(1100px, 90vw);
+  margin: 24px auto 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 0;
+}
+
+.site-header nav {
+  display: flex;
+  gap: 20px;
+  font-weight: 500;
+}
+
+.site-header a {
+  color: var(--muted);
+  text-decoration: none;
+  position: relative;
+}
+
+.site-header a::after {
+  content: "";
+  position: absolute;
+  bottom: -6px;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: var(--accent);
+  opacity: 0;
+  transform: translateY(4px);
+  transition: 0.2s ease;
+}
+
+.site-header a:hover::after {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1.2rem;
+}
+
+.theme-toggle {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 6px 12px;
+  background: var(--card);
+  cursor: pointer;
+  display: flex;
+  gap: 8px;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 32px;
+  padding: 48px;
+  background: radial-gradient(circle at top right, #dbeafe, transparent 60%),
+    var(--card);
+  border-radius: 32px;
+  border: 1px solid var(--border);
+}
+
+.hero h1 {
+  font-size: clamp(2.4rem, 4vw, 3.6rem);
+  line-height: 1.2;
+  margin-bottom: 16px;
+}
+
+.hero .lead {
+  color: var(--muted);
+}
+
+.hero-cta {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin: 24px 0 16px;
+}
+
+.btn {
+  border-radius: 999px;
+  padding: 12px 24px;
+  text-decoration: none;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+
+.btn.primary {
+  background: var(--accent);
+  color: #fff;
+}
+
+.btn.ghost {
+  border-color: var(--border);
+  color: var(--fg);
+}
+
+.stats {
+  list-style: none;
+  padding: 0;
+  margin: 32px 0 0;
+  display: flex;
+  gap: 32px;
+  flex-wrap: wrap;
+}
+
+.stats span {
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.hero-card {
+  padding: 24px;
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  background: var(--bg);
+}
+
+.hero-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.card-title {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.section-heading {
+  max-width: 680px;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  color: var(--accent);
+  letter-spacing: 0.25em;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.about-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 24px;
+  margin-top: 32px;
+}
+
+.about-grid article {
+  padding: 24px;
+  border-radius: 24px;
+  border: 1px solid var(--border);
+  background: var(--card);
+}
+
+.writing .filters {
+  margin: 24px 0 32px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.tags {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.tag-button {
+  border-radius: 999px;
+  padding: 8px 16px;
+  border: 1px solid var(--border);
+  background: transparent;
+  cursor: pointer;
+  font-weight: 500;
+  color: var(--muted);
+}
+
+.tag-button.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+#search {
+  flex: 1;
+  min-width: 220px;
+  border-radius: 16px;
+  padding: 10px 16px;
+  border: 1px solid var(--border);
+  background: var(--card);
+  color: var(--fg);
+}
+
+.featured {
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  padding: 32px;
+  background: linear-gradient(120deg, rgba(37, 99, 235, 0.08), transparent);
+  margin-bottom: 32px;
+}
+
+.featured h3 {
+  margin-top: 0;
+}
+
+.post-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+}
+
+.post-card {
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: 24px;
+  background: var(--card);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.post-card .meta {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.post-card .tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: 0.8rem;
+  color: var(--accent);
+}
+
+.newsletter,
+.contact {
+  border: 1px solid var(--border);
+  border-radius: 32px;
+  padding: 48px;
+  background: var(--card);
+}
+
+.subscribe-form,
+.contact-form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.subscribe-form input,
+.contact-form input,
+.contact-form textarea {
+  width: 100%;
+  padding: 12px 16px;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg);
+}
+
+.contact-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: 500;
+}
+
+.contact-info {
+  margin-top: 32px;
+}
+
+.contact-info ul {
+  padding: 0;
+  list-style: none;
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+  color: var(--muted);
+}
+
+.tiny {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.site-footer {
+  text-align: center;
+  padding: 32px 0 64px;
+  color: var(--muted);
+}
+
+@media (max-width: 720px) {
+  .site-header {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .hero,
+  .newsletter,
+  .contact {
+    padding: 32px;
+  }
+
+  .stats {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static personal blog landing page with hero, about, writing, newsletter, and contact sections
- style the page with a modern responsive layout plus dark mode support
- add JavaScript to render posts dynamically, filter by tag/search, toggle theme, and handle basic forms

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915adff17ec833284d2560d2c2df24b)